### PR TITLE
Multi-platform image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -41,6 +44,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM ocamlpro/ocaml:4.14
+FROM alpine:3.17
 LABEL org.opencontainers.image.authors="Christoph Knittel <ck@cca.io>"
 LABEL org.opencontainers.image.description="Alpine-based Docker image for building statically linked ReScript binaries."
 
-USER ocaml
-RUN opam switch create ocaml-system
-RUN opam update
-RUN opam install dune cppo=1.6.9 js_of_ocaml-compiler=4.0.0 ocamlformat=0.22.4 ounit2=2.2.6 reanalyze=2.23.0
+# - gcompat needed for ARM64, see https://github.com/actions/runner/issues/801#issuecomment-1374967227
+# - python3 needed for ninja build
+RUN apk add --no-cache bash gcc g++ git make opam python3 rsync gcompat
 
-USER root
+# We need to specify the OPAM dir explicitly as the GitHub Actions runner
+# will set a different home directory when running in a container.
+ENV OPAMROOT /root/.opam
 
-# Needed for ninja compilation
-RUN apk add g++ python3
+RUN opam init -y --compiler=4.14.0 --disable-sandboxing
+
+RUN opam install -y dune cppo=1.6.9 js_of_ocaml-compiler=4.0.0 ocamlformat=0.22.4 ounit2=2.2.6 reanalyze=2.23.0


### PR DESCRIPTION
This makes our Linux CI Build image multi-platform so that we can build statically linked Linux arm64 binaries in the rescript-compiler CI.